### PR TITLE
feat: add serial port implementation for linux

### DIFF
--- a/lib/dart_serialport.dart
+++ b/lib/dart_serialport.dart
@@ -2,4 +2,5 @@
 library dart_serialport;
 
 export 'src/serial_device_information/serial_device_information.dart';
+export 'src/serial_port/serial_port.dart';
 export 'src/serial_port_list.dart' show SerialPortList;

--- a/lib/dart_serialport.dart
+++ b/lib/dart_serialport.dart
@@ -1,4 +1,4 @@
-/// A Very Good Project created by Very Good CLI.
+/// a library to access serial ports on all platforms.
 library dart_serialport;
 
 export 'src/serial_device_information/serial_device_information.dart';

--- a/lib/src/serial_port/serial_port.dart
+++ b/lib/src/serial_port/serial_port.dart
@@ -1,0 +1,94 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:io';
+
+import 'package:dart_serialport/src/serial_port/serial_port_linux.dart';
+
+enum Parity {
+  none,
+  odd,
+  even,
+  mark,
+  space,
+}
+
+enum DataBits {
+  five,
+  six,
+  seven,
+  eight,
+}
+
+enum StopBits {
+  one,
+  onePointFive,
+  two,
+}
+
+/// configuration for a SerialPort
+class SerialPortConfig {
+  /// configuration for a SerialPort
+  SerialPortConfig({
+    required this.port,
+    this.baudRate = 9600,
+    this.dataBits = DataBits.eight,
+    this.stopBits = StopBits.one,
+    this.parity = Parity.none,
+    this.timeout = Duration.zero,
+    this.xonxoff = false,
+  });
+
+  /// the port to connect to
+  /// path on linux, COM{num} on windows
+  /// e.g. /dev/ttyUSB0
+  final String port;
+
+  /// the baud rate to use
+  /// e.g. 9600
+  final int baudRate;
+
+  /// the number of data bits to use
+  /// e.g. 8
+  final DataBits dataBits;
+
+  /// the number of stop bits to use
+  final StopBits stopBits;
+
+  /// the parity to use
+  final Parity parity;
+
+  /// read timeout
+  final Duration timeout;
+
+  // enable software flow control
+  final bool xonxoff;
+
+  // enable hardware flow control
+  final rtscts = false;
+}
+
+abstract class SerialPort {
+  factory SerialPort(SerialPortConfig config) {
+    if (Platform.isLinux) {
+      return SerialPortLinux(config);
+    }
+
+    throw UnsupportedError('Platform not supported');
+  }
+
+  SerialPortConfig get config;
+
+  void open();
+
+  void close();
+
+  void flush();
+
+  List<int> read(int length);
+
+  void write(List<int> data);
+
+  int get inWaiting;
+
+  int get outWaiting;
+}

--- a/lib/src/serial_port/serial_port_linux.dart
+++ b/lib/src/serial_port/serial_port_linux.dart
@@ -1,0 +1,118 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:dart_periphery/dart_periphery.dart' as periphery;
+import 'package:dart_serialport/src/serial_port/serial_port.dart';
+
+class SerialPortLinux implements SerialPort {
+  SerialPortLinux(this.config);
+
+  @override
+  SerialPortConfig config;
+
+  periphery.Serial? _serial;
+
+  @override
+  void close() {
+    _serial?.dispose();
+    _serial = null;
+  }
+
+  @override
+  void open() {
+    _serial = periphery.Serial.advanced(
+      config.port,
+      _getBaudrate(),
+      _getDataBits(),
+      _getParity(),
+      _getStopBits(),
+      config.xonxoff,
+      config.rtscts,
+    );
+  }
+
+  @override
+  void flush() {
+    if (_serial == null) throw StateError('SerialPort is not open');
+
+    _serial?.flush();
+  }
+
+  @override
+  int get inWaiting {
+    final serial = _serial;
+    if (serial == null) throw StateError('SerialPort is not open');
+    return serial.getInputWaiting();
+  }
+
+  @override
+  int get outWaiting {
+    final serial = _serial;
+    if (serial == null) throw StateError('SerialPort is not open');
+    return serial.getOutputWaiting();
+  }
+
+  @override
+  List<int> read(int length) {
+    final serial = _serial;
+    if (serial == null) throw StateError('SerialPort is not open');
+
+    final data = serial.read(
+      length,
+      config.timeout == Duration.zero ? -1 : config.timeout.inMilliseconds,
+    );
+    return data.data;
+  }
+
+  @override
+  void write(List<int> data) {
+    final serial = _serial;
+    if (serial == null) throw StateError('SerialPort is not open');
+
+    serial.write(data);
+  }
+
+  periphery.Baudrate _getBaudrate() {
+    return periphery.Baudrate.values.firstWhere(
+      (element) => element.name == 'b${config.baudRate}',
+      orElse: () => periphery.Baudrate.b9600,
+    );
+  }
+
+  periphery.DataBits _getDataBits() {
+    switch (config.dataBits) {
+      case DataBits.five:
+        return periphery.DataBits.db5;
+      case DataBits.six:
+        return periphery.DataBits.db6;
+      case DataBits.seven:
+        return periphery.DataBits.db7;
+      case DataBits.eight:
+        return periphery.DataBits.db8;
+    }
+  }
+
+  periphery.Parity _getParity() {
+    switch (config.parity) {
+      case Parity.none:
+        return periphery.Parity.parityNone;
+      case Parity.odd:
+        return periphery.Parity.parityOdd;
+      case Parity.even:
+        return periphery.Parity.parityEven;
+      case Parity.mark:
+      case Parity.space:
+        throw UnsupportedError('parity $config.parity is not supported');
+    }
+  }
+
+  periphery.StopBits _getStopBits() {
+    switch (config.stopBits) {
+      case StopBits.one:
+        return periphery.StopBits.sb1;
+      case StopBits.two:
+        return periphery.StopBits.sb2;
+      case StopBits.onePointFive:
+        throw UnsupportedError('stopBits $config.stopBits is not supported');
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,11 @@
 name: dart_serialport
-description: A Very Good Project created by Very Good CLI.
-version: 0.1.0+1
+description: Dart package that aims to provide a platform-independent serial port API.
+version: 0.1.0-alpha.1
+license: MIT
+repository: https://github.com/frickly-systems/dart_serialport
+
+platforms:
+  linux:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
+  dart_periphery: ^0.9.5
   equatable: ^2.0.5
   glob: ^2.1.2
   meta: ^1.9.1

--- a/test/src/serial_port_list_test.dart
+++ b/test/src/serial_port_list_test.dart
@@ -1,17 +1,12 @@
 // ignore_for_file: prefer_const_constructors
-import 'package:dart_serialport/dart_serialport.dart';
 import 'package:dart_serialport/src/serial_port_list.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('DartSerialport', () {
+  group('SerialPortListLinux', () {
     test('can list ports', () async {
       final ports = await SerialPortListLinux().listEntries();
 
-      for (final port
-          in ports.where((element) => element.deviceName == 'ttyACM0')) {
-        print(port as USBDeviceInformation);
-      }
       expect(ports, isNotEmpty);
     });
   });

--- a/test/src/serial_port_test.dart
+++ b/test/src/serial_port_test.dart
@@ -1,9 +1,7 @@
 // ignore_for_file: prefer_const_constructors
-import 'dart:math';
 
 import 'package:dart_serialport/src/serial_port/serial_port.dart';
 import 'package:dart_serialport/src/serial_port/serial_port_linux.dart';
-import 'package:dart_serialport/src/serial_port_list.dart';
 import 'package:test/test.dart';
 
 // NOTE: This test must have two connected serial ports

--- a/test/src/serial_port_test.dart
+++ b/test/src/serial_port_test.dart
@@ -1,0 +1,59 @@
+// ignore_for_file: prefer_const_constructors
+import 'dart:math';
+
+import 'package:dart_serialport/src/serial_port/serial_port.dart';
+import 'package:dart_serialport/src/serial_port/serial_port_linux.dart';
+import 'package:dart_serialport/src/serial_port_list.dart';
+import 'package:test/test.dart';
+
+// NOTE: This test must have two connected serial ports
+// /tmp/ttyV0
+// /tmp/ttyV1
+// e.g. run: socat -d -d pty,rawer,echo=0,link=/tmp/ttyV0 pty,rawer,echo=0,link=/tmp/ttyV1
+void main() {
+  group('SerialPortLinux', () {
+    final config1 = SerialPortConfig(port: '/tmp/ttyV0');
+    late final SerialPortLinux port;
+
+    final config2 = SerialPortConfig(port: '/tmp/ttyV1');
+    late final SerialPortLinux port2;
+
+    setUp(() async {
+      port = SerialPortLinux(config1);
+      port2 = SerialPortLinux(config2);
+    });
+
+    tearDown(() {
+      port.close();
+      port2.close();
+    });
+
+    test('can open port', () async {
+      port.open();
+    });
+
+    test('can send data', () async {
+      port
+        ..open()
+        ..write([1, 2, 3])
+        ..flush();
+
+      await Future<void>.delayed(Duration(milliseconds: 10));
+
+      expect(port.outWaiting, 0);
+    });
+
+    test('can receive data', () async {
+      port.open();
+
+      port2
+        ..open()
+        ..write([1, 2, 3])
+        ..flush();
+
+      await Future<void>.delayed(Duration(milliseconds: 10));
+
+      expect(port.read(3), [1, 2, 3]);
+    });
+  });
+}

--- a/test/src/serial_port_test.dart
+++ b/test/src/serial_port_test.dart
@@ -11,10 +11,10 @@ import 'package:test/test.dart';
 void main() {
   group('SerialPortLinux', () {
     final config1 = SerialPortConfig(port: '/tmp/ttyV0');
-    late final SerialPortLinux port;
+    late SerialPortLinux port;
 
     final config2 = SerialPortConfig(port: '/tmp/ttyV1');
-    late final SerialPortLinux port2;
+    late SerialPortLinux port2;
 
     setUp(() async {
       port = SerialPortLinux(config1);


### PR DESCRIPTION
Add a serial port implementation for linux.
This implementation uses the dart_periphery package to provide the implementation for linux.
As this already has a lot of options and supports arm as well as x86 (both 32bit and 64bit) this is a good start.